### PR TITLE
[feat] #3 Lv2 6~8 요구사항 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/expert/config/QueryDslConfig.java
+++ b/src/main/java/org/example/expert/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package org.example.expert.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.todo.id = :todoId")
     List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
 }

--- a/src/main/java/org/example/expert/domain/todo/entity/Todo.java
+++ b/src/main/java/org/example/expert/domain/todo/entity/Todo.java
@@ -30,7 +30,7 @@ public class Todo extends Timestamped {
     @OneToMany(mappedBy = "todo", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "todo")
+    @OneToMany(mappedBy = "todo", cascade = CascadeType.PERSIST)
     private List<Manager> managers = new ArrayList<>();
 
     public Todo(String title, String contents, String weather, User user) {

--- a/src/main/java/org/example/expert/domain/todo/repository/CustomTodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/CustomTodoRepository.java
@@ -1,0 +1,9 @@
+package org.example.expert.domain.todo.repository;
+
+import org.example.expert.domain.todo.entity.Todo;
+
+import java.util.Optional;
+
+public interface CustomTodoRepository {
+    Optional<Todo> findByIdWithUser(Long todoId);
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -8,9 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
-public interface TodoRepository extends JpaRepository<Todo, Long> {
+public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRepository {
 
     @Query("""
     SELECT t FROM Todo t
@@ -25,8 +24,4 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             Pageable pageable
     );
 
-    @Query("SELECT t FROM Todo t " +
-            "LEFT JOIN t.user " +
-            "WHERE t.id = :todoId")
-    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
@@ -1,0 +1,31 @@
+package org.example.expert.domain.todo.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.todo.entity.QTodo;
+import org.example.expert.domain.todo.entity.Todo;
+import org.example.expert.domain.user.entity.QUser;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TodoRepositoryImpl implements CustomTodoRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Todo> findByIdWithUser(Long todoId) {
+        QTodo todo = QTodo.todo;
+        QUser user = QUser.user;
+
+        Todo result = queryFactory
+                .selectFrom(todo)
+                .leftJoin(todo.user, user).fetchJoin() // N+1 문제 방지
+                .where(todo.id.eq(todoId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}


### PR DESCRIPTION
## 📚 작업 개요

closes #3 

Level.2 과제의 전체 요구사항(6~8번)에 대한 기능 구현 및 코드 개선을 반영한 PR입니다.



## 🛠️ 상세 작업 내용

### 💡 6. JPA Cascade 적용

- `@OneToMany(cascade = CascadeType.PERSIST)`를 활용하여 할 일 저장 시 담당자도 자동 저장되도록 처리

### 💡 7. N+1 문제 해결 - Comment 조회
- `Comment` 조회 시 발생하던 N+1 문제를 `JOIN FETCH`로 해결
- `CommentRepository.findByTodoIdWithUser()` 메서드에 JPQL `JOIN FETCH` 적용 → 댓글과 작성자(User)를 한 번의 쿼리로 조회

### 💡 8. QueryDSL로 JPQL 대체
- 기존 JPQL 기반 `findByIdWithUser()` 메서드를 QueryDSL로 리팩토링
- `QTodo`와 `QUser`를 사용하여 연관 유저 정보를 fetch join으로 조회
- N+1 문제 없이 `Todo`와 `User`가 함께 로딩되도록 구현



## 🧐 질문 사항
QueryDSL로 커스텀 레포지토리를 만들 때, 이름을 지을 때 따로 정해진 규칙이나 통일된 방식이 있는지 궁금합니다!














































