### PR TITLE
[feat] #6 QueryDSL 을 사용하여 검색 기능 만들기

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -5,10 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
+import org.example.expert.domain.todo.dto.request.TodoSearchRequest;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.service.TodoService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,18 +33,25 @@ public class TodoController {
     }
 
     @GetMapping("/todos")
-    public ResponseEntity<Page<TodoResponse>> searchTodos(
+    public ResponseEntity<Page<TodoResponse>> getTodos(
             @RequestParam(required = false) String weather,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(todoService.searchTodos(weather, startDate, endDate, page, size));
+        return ResponseEntity.ok(todoService.getTodos(weather, startDate, endDate, page, size));
     }
 
     @GetMapping("/todos/{todoId}")
     public ResponseEntity<TodoResponse> getTodo(@PathVariable long todoId) {
         return ResponseEntity.ok(todoService.getTodo(todoId));
     }
+
+    @GetMapping("/todos/search")
+    public ResponseEntity<Page<TodoSearchResponse>> searchTodos(
+            @ModelAttribute TodoSearchRequest todoSearchRequest, Pageable pageable) {
+        return ResponseEntity.ok(todoService.searchTodos(todoSearchRequest, pageable));
+    }
+
 }

--- a/src/main/java/org/example/expert/domain/todo/dto/request/TodoSearchRequest.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/request/TodoSearchRequest.java
@@ -1,0 +1,17 @@
+package org.example.expert.domain.todo.dto.request;
+
+import java.time.LocalDate;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class TodoSearchRequest {
+    private Integer page = 1;
+    private Integer size = 10;
+    private LocalDate from;
+    private LocalDate to;
+    private String title;
+    private String managerNickname;
+}

--- a/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
@@ -1,0 +1,8 @@
+package org.example.expert.domain.todo.dto.response;
+
+public record TodoSearchResponse(
+        String title,
+        long managerCount,
+        long commentCount
+) {
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/CustomTodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/CustomTodoRepository.java
@@ -1,9 +1,16 @@
 package org.example.expert.domain.todo.repository;
 
+import org.example.expert.domain.todo.dto.request.TodoSearchRequest;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface CustomTodoRepository {
     Optional<Todo> findByIdWithUser(Long todoId);
+
+    Page<TodoSearchResponse> searchTodos(
+            TodoSearchRequest todoSearchRequest, Pageable pageable);
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
@@ -1,12 +1,23 @@
 package org.example.expert.domain.todo.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.comment.entity.QComment;
+import org.example.expert.domain.manager.entity.QManager;
+import org.example.expert.domain.todo.dto.request.TodoSearchRequest;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.QTodo;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.user.entity.QUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -28,4 +39,66 @@ public class TodoRepositoryImpl implements CustomTodoRepository {
 
         return Optional.ofNullable(result);
     }
+
+
+    @Override
+    public Page<TodoSearchResponse> searchTodos(TodoSearchRequest todoSearchRequest, Pageable pageable) {
+
+        QTodo todo = QTodo.todo;
+        QUser user = QUser.user;
+        QManager manager = QManager.manager;
+        QComment comment = QComment.comment;
+
+        // BooleanExpression 조건들 정의
+        BooleanExpression titleCondition = hasTitle(todoSearchRequest.getTitle(), todo);
+        BooleanExpression nicknameCondition = hasManagerNickname(todoSearchRequest.getManagerNickname(), user);
+        BooleanExpression fromCondition = createdAtFrom(todoSearchRequest.getFrom(), todo);
+        BooleanExpression toCondition = createdAtTo(todoSearchRequest.getTo(), todo);
+
+        // 메인 쿼리
+        List<TodoSearchResponse> result = queryFactory
+                .select(Projections.constructor(TodoSearchResponse.class,
+                        todo.title,
+                        manager.id.countDistinct(),   // 담당자 수
+                        comment.id.countDistinct()    // 댓글 수
+                ))
+                .from(todo)
+                .leftJoin(todo.managers, manager)
+                .leftJoin(manager.user, user)
+                .leftJoin(todo.comments, comment)
+                .where(titleCondition, nicknameCondition, fromCondition, toCondition)
+                .groupBy(todo.id)
+                .orderBy(todo.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 카운트 쿼리
+        Long total = queryFactory
+                .select(todo.id.countDistinct())
+                .from(todo)
+                .leftJoin(todo.managers, manager)
+                .leftJoin(manager.user, user)
+                .where(titleCondition, nicknameCondition, fromCondition, toCondition)
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression hasTitle(String title, QTodo todo) {
+        return (title != null && !title.isBlank()) ? todo.title.containsIgnoreCase(title) : null;
+    }
+
+    private BooleanExpression hasManagerNickname(String nickname, QUser user) {
+        return (nickname != null && !nickname.isBlank()) ? user.nickname.containsIgnoreCase(nickname) : null;
+    }
+
+    private BooleanExpression createdAtFrom(LocalDate from, QTodo todo) {
+        return (from != null) ? todo.createdAt.goe(from.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtTo(LocalDate to, QTodo todo) {
+        return (to != null) ? todo.createdAt.loe(to.atTime(23, 59, 59)) : null;
+    }
+
 }

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -5,8 +5,10 @@ import org.example.expert.client.WeatherClient;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
+import org.example.expert.domain.todo.dto.request.TodoSearchRequest;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
 import org.example.expert.domain.user.dto.response.UserResponse;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.springframework.transaction.annotation.Propagation.SUPPORTS;
@@ -52,7 +55,7 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true, propagation = SUPPORTS)
-    public Page<TodoResponse> searchTodos(String weather, LocalDateTime startDate, LocalDateTime endDate, int page, int size) {
+    public Page<TodoResponse> getTodos(String weather, LocalDateTime startDate, LocalDateTime endDate, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
         return todoRepository.searchTodosWithConditions(weather, startDate, endDate, pageable)
@@ -85,4 +88,10 @@ public class TodoService {
                 todo.getModifiedAt()
         );
     }
+
+    @Transactional(readOnly = true)
+    public Page<TodoSearchResponse> searchTodos(TodoSearchRequest todoSearchRequest, Pageable pageable) {
+        return todoRepository.searchTodos(todoSearchRequest, pageable);
+    }
+
 }


### PR DESCRIPTION
## 📚 작업 개요

closes #6 

Level.3 과제의 10번 요구사항(일정 검색 기능) 구현 및 QueryDSL 최적화 PR입니다.

---

## 🛠️ 상세 작업 내용

### 💡 QueryDSL을 사용하여 일정 검색 기능 구현

- **QueryDSL**로 검색 기능을 새로 구축
- QueryDSL의 장점을 최대한 활용:
    - ✅ **Projections.constructor** 사용 → 필요한 필드만 선택하여 DTO에 매핑 (성능 최적화)
    - ✅ **BooleanExpression 방식** 선택 → 각 조건을 메서드로 분리해 깔끔하고 재사용 가능한 구조로 설계
    - ✅ **페이징 처리** → QueryDSL `.offset()`, `.limit()` 메서드로 처리


### 📌 **검색 조건 및 처리**

- 제목 (`title`) → 부분 일치 검색 (`containsIgnoreCase`)
- 담당자 닉네임 (`managerNickname`) → 부분 일치 검색 (`containsIgnoreCase`)
- 생성일 (`createdAt`) → 범위 검색 (`from`, `to`)

위 조건들은 전부 단순 AND로 결합되므로,

✅ BooleanExpression 방식이 더 적합하다고 판단했습니다.

❗ BooleanBuilder 방식은 복잡한 OR 조합, 다단 조건, 반복 조건이 필요할 때 더 강력하지만, 현재 요구사항은 BooleanExpression으로 충분히 깔끔하게 처리 가능하다고 봤습니다.

### 💡 최종 반환 데이터

- 일정 제목
- 담당자 수 (distinct count)
- 댓글 수 (distinct count)

→ QueryDSL의 `.countDistinct()`로 groupBy 쿼리 최적화


### 🔍 성능 최적화 고려

- 필요한 필드만 가져오는 Projections 사용 → 불필요한 Entity 로딩 방지
- N+1 문제 발생하지 않도록 left join + groupBy 설계
- 별도 count 쿼리로 total count 조회 → Page 객체 구성

---

## 🧐 질문 사항

1. QueryDSL에서 동적 쿼리 작성 시, 현업에서도 BooleanExpression 방식과 BooleanBuilder 방식은 어떤 기준으로 선택하는지 궁금합니다. 특히, 단순 AND 조건만 있는 경우에도 BooleanBuilder를 쓰는 사례가 있는지, 아니면 일반적으로 BooleanExpression 방식이 권장되는지 궁금합니다!

1. 검색 API를 아래처럼 @GetMapping으로 작성하면서, 쿼리 파라미터를 `@ModelAttribute`로 `TodoSearchRequest` DTO에 매핑했습니다.

```java
@GetMapping("/todos/search")
public ResponseEntity<Page<TodoSearchResponse>> searchTodos(
        @ModelAttribute TodoSearchRequest todoSearchRequest, Pageable pageable) {
    return ResponseEntity.ok(todoService.searchTodos(todoSearchRequest, pageable));
}
```

이런 방식(@GetMapping + @ModelAttribute DTO 바인딩)은 일반적으로 자주 쓰이는 방법인가요?

`@PostMapping`으로 요청 본문을 받아야 하나 고민했어서 여쭤봅니다 ! 혹시 더 좋은 설계 방식이나 주의할 점이 있을까요?

3. 저는 평소에 요청 DTO와 응답 DTO 모두 `record`로 작성해왔습니다. (record의 특징 때문에 record가 더 깔끔하고 유지보수가 편하다고 느껴서 선호해왔습니다 !) 그런데 이번 과제에서  `@ModelAttribute`로 요청 DTO를 받으려다 보니, Spring이 내부적으로 객체를 생성하고 setter로 바인딩하기 때문에 기본 생성자 + setter가 필요했습니다. 그래서 이번에는 요청 DTO는 `class` 로, 응답 DTO → `record` 로 설계했습니다. 이런 설계(class + record) 는 괜찮은 선택인지, 아니면 프로젝트 일관성을 위해 둘 다 `class`로 맞추는 게 더 좋은지 궁금합니다.  또, QueryDSL을 사용하는 경우 응답 DTO로 record를 쓰는 것이 문제될 소지가 있는지, 혹은 QueryDSL에서는 class를 사용하는 것이 더 권장되는 이유가 있다면 알려주시면 감사하겠습니다!