### PR TITLE
[feat] #8 Transaction 심화

### DIFF
--- a/src/main/java/org/example/expert/domain/log/entity/Log.java
+++ b/src/main/java/org/example/expert/domain/log/entity/Log.java
@@ -1,0 +1,36 @@
+package org.example.expert.domain.log.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.log.enums.LogStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "log")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Log {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LogStatus status;
+
+    public void changeStatus(LogStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/enums/LogStatus.java
+++ b/src/main/java/org/example/expert/domain/log/enums/LogStatus.java
@@ -1,0 +1,7 @@
+package org.example.expert.domain.log.enums;
+
+public enum LogStatus {
+    IN_PROGRESS,
+    SUCCESS,
+    FAIL
+}

--- a/src/main/java/org/example/expert/domain/log/repository/LogRepository.java
+++ b/src/main/java/org/example/expert/domain/log/repository/LogRepository.java
@@ -1,0 +1,9 @@
+package org.example.expert.domain.log.repository;
+
+import org.example.expert.domain.log.entity.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LogRepository extends JpaRepository<Log, Long> {
+}

--- a/src/main/java/org/example/expert/domain/log/service/LogService.java
+++ b/src/main/java/org/example/expert/domain/log/service/LogService.java
@@ -1,0 +1,37 @@
+package org.example.expert.domain.log.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.log.entity.Log;
+import org.example.expert.domain.log.enums.LogStatus;
+import org.example.expert.domain.log.repository.LogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+
+    private final LogRepository logRepository;
+
+    // 로그 시작 -> 기존 트랜잭션 무시하고, 새 트랜잭션 실행
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Log startLog(String message) {
+        Log log = Log.builder()
+                .message(message)
+                .createdAt(LocalDateTime.now())
+                .status(LogStatus.IN_PROGRESS)
+                .build();
+
+        return logRepository.save(log);
+    }
+
+    // 로그 상태 업데이트
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateLogStatus(Long logId, LogStatus status) {
+        Log log = logRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("Log not found"));
+        log.changeStatus(status);
+    }
+}

--- a/src/main/java/org/example/expert/domain/manager/controller/ManagerController.java
+++ b/src/main/java/org/example/expert/domain/manager/controller/ManagerController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;
+import org.example.expert.domain.manager.dto.request.ManagerRequest;
 import org.example.expert.domain.manager.dto.request.ManagerSaveRequest;
 import org.example.expert.domain.manager.dto.response.ManagerResponse;
 import org.example.expert.domain.manager.dto.response.ManagerSaveResponse;
@@ -41,4 +42,11 @@ public class ManagerController {
     ) {
         managerService.deleteManager(authUser, todoId, managerId);
     }
+
+    @PostMapping("/managers")
+    public ResponseEntity<Void> registerManager(@RequestBody ManagerRequest managerRequest) {
+        managerService.registerManager(managerRequest);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/org/example/expert/domain/manager/dto/request/ManagerRequest.java
+++ b/src/main/java/org/example/expert/domain/manager/dto/request/ManagerRequest.java
@@ -1,0 +1,14 @@
+package org.example.expert.domain.manager.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ManagerRequest {
+    private Long userId;  // 매니저로 등록할 User의 id
+    private Long todoId;  // 등록할 일정의 id
+
+}

--- a/src/main/java/org/example/expert/domain/manager/entity/Manager.java
+++ b/src/main/java/org/example/expert/domain/manager/entity/Manager.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.manager.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.expert.domain.todo.entity.Todo;
@@ -17,11 +18,13 @@ public class Manager {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false) // 일정 만든 사람 id
-    private User user;
+    private User user; // 매니저 역할을 하는 유저
+
     @ManyToOne(fetch = FetchType.LAZY) // 일정 id
     @JoinColumn(name = "todo_id", nullable = false)
-    private Todo todo;
+    private Todo todo; // 어떤 일정에 매니저로 등록됐는지
 
+    @Builder
     public Manager(User user, Todo todo) {
         this.user = user;
         this.todo = todo;


### PR DESCRIPTION
## 📚 작업 개요

closes #8 
Level.3 과제 11번 요구사항(매니저 등록 시 로그 남기기) 구현 PR입니다.



## 🛠️ 작업 내용 요약

### ✅ 매니저 등록 + 로그 기록

- `LogService` → `@Transactional(propagation = REQUIRES_NEW)` 적용
- 메인 트랜잭션과 별도로 로그는 **항상 커밋**되도록 처리


### 🌀 처리 흐름

1️⃣ `LogService.startLog()` → 로그 생성 (IN_PROGRESS)
2️⃣ 매니저 등록 진행
3️⃣ 성공: 로그 상태 → SUCCESS / 실패: 로그 상태 → FAIL


### 예시 로그

![image](https://github.com/user-attachments/assets/7598ea92-e107-4f1a-862c-61dea04406b8)
