### PR TITLE
[infra] S3 연동 및 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // s3
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/expert/config/S3Config.java
+++ b/src/main/java/org/example/expert/config/S3Config.java
@@ -1,0 +1,31 @@
+package org.example.expert.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/org/example/expert/domain/s3/controller/ProfileController.java
+++ b/src/main/java/org/example/expert/domain/s3/controller/ProfileController.java
@@ -1,0 +1,46 @@
+package org.example.expert.domain.s3.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.s3.service.S3Service;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final S3Service s3Service;
+
+    /**
+     * 프로필 이미지 업로드 API
+     * - 사용자로부터 파일과 userId를 form-data 형식으로 전달받아 S3에 저장
+     * - 저장된 이미지의 URL을 응답으로 반환
+     *
+     * @param file 업로드할 이미지 파일 (.jpg/.png)
+     * @param userId 해당 이미지를 업로드한 사용자 ID
+     * @return 업로드된 이미지의 URL (S3 공개 주소)
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<String> upload(@RequestParam MultipartFile file,
+                                         @RequestParam String userId) {
+        String imageUrl = s3Service.uploadProfileImage(file, userId);
+        return ResponseEntity.ok(imageUrl);
+    }
+
+
+    /**
+     * 프로필 이미지 삭제 API
+     * - 클라이언트가 전달한 이미지 URL을 바탕으로 S3에서 해당 이미지 삭제
+     *
+     * @param fileUrl 삭제할 이미지의 전체 URL
+     * @return HTTP 200 OK
+     */
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> delete(@RequestParam String fileUrl) {
+        s3Service.deleteProfileImage(fileUrl);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/org/example/expert/domain/s3/service/S3Service.java
+++ b/src/main/java/org/example/expert/domain/s3/service/S3Service.java
@@ -1,0 +1,42 @@
+package org.example.expert.domain.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadProfileImage(MultipartFile file, String userId) {
+        String fileName = "profile/" + userId + "_" + file.getOriginalFilename();
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+
+        try {
+            // ACL 없이 업로드 (버킷 정책에 따라 접근 가능 여부 결정됨)
+            PutObjectRequest request = new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata);
+            amazonS3.putObject(request);
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    public void deleteProfileImage(String fileUrl) {
+        String key = fileUrl.substring(fileUrl.indexOf("profile/")); // key 추출
+        amazonS3.deleteObject(bucket, key);
+    }
+}


### PR DESCRIPTION
## 📚 작업 개요
closes #15 

---

## 🛠️ 작업 내용 요약
- 사용자 프로필 이미지 업로드 기능 구현
- AWS S3에 이미지를 업로드하고 Public URL을 반환
- SDK는 Spring 연동성과 학습 비용을 고려하여 v1 (`com.amazonaws.services.s3`) 사용


### ✅ 주요 구현 사항
- `ProfileController`: 이미지 업로드/삭제 API 구현 (`/profile/upload`, `/profile/delete`)
- `S3Service`: S3에 이미지 업로드 및 삭제 로직 분리
- 파일은 `"profile/{userId}_{fileName}"` 경로로 저장됨
- 업로드 후 이미지 URL 반환


### 🤔 SDK 선택 배경

| 항목 | SDK v1 | SDK v2 |
|------|--------|--------|
| Spring 연동 | ✅ 자동 구성 지원 (Spring Cloud AWS) | ❌ 수동 설정 필요 |
| 사용 난이도 | 낮음 (코드 많음) | 높음 (builder 패턴, 모듈화됨) |
| 공식 권장 여부 | ❌ 유지보수 위주 | ✅ 기능 확장 및 경량화 지원 |
| Presigned URL 등 최신 기능 | 지원은 됨 (복잡) | ✅ 쉽게 사용 가능 |

- AWS는 SDK v2를 권장하지만, Spring Cloud AWS 환경에서는 v1이 여전히 더 편리함
- 현재는 빠른 구현과 테스트 목적에 집중하여 v1으로 구성

## 정리 블로그
https://yeunever.tistory.com/46
해당 내용 참고해주시면 좋을 것 같습니다.
